### PR TITLE
enabled R8 for release build

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,3 @@
 /build
+/release
+/debug

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,7 +58,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
@@ -96,9 +97,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
-    //biometric
-    implementation "androidx.biometric:biometric:$biometric_version"
-
     // common
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
@@ -132,9 +130,6 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
-
-    //preference
-    implementation "androidx.preference:preference-ktx:$preference_version"
 
     //compose
     implementation "androidx.compose.ui:ui:$compose_version"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,5 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# preserve the line number information for debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
 # hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-renamesourcefileattribute SourceFile

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.10'
+    ext.kotlin_version = '1.5.21'
     ext.navigationVersion = '2.3.5'
-    ext.hilt_version = '2.37'
+    ext.hilt_version = '2.38.1'
 
     repositories {
         google()
@@ -33,7 +33,7 @@ ext{
     biometric_version='1.1.0'
     room_version='2.3.0'
     preference_version='1.1.1'
-    compose_version = '1.0.0'
+    compose_version = '1.0.1'
 }
 
 allprojects {


### PR DESCRIPTION
Signed-off-by: Nitin Verma <canvas.nv@gmail.com>

# Description
Enabling R8 for release build.

Please include a summary of the change that you have done.
by enabling R8 and shrink resource I was able to bring down apk size from 8mb to 3mb.

Fixes #59 

# Type of change
Enhancement

# Code quality checklist
Just put an x in the [] where applicable.
- [x] I ran `gradlew lint` and found no new error related to my code in the report.
- [x] I have verified my changes on an emulator/ real device.
- [x] I have added proper comments where code is complex.
