### PR TITLE
get value from settings data store instead of collecting flow

### DIFF
--- a/app/src/main/java/com/andryoga/safebox/data/dataStore/SettingsDataStore.kt
+++ b/app/src/main/java/com/andryoga/safebox/data/dataStore/SettingsDataStore.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.io.IOException
 import javax.inject.Inject
@@ -68,14 +69,22 @@ class SettingsDataStore @Inject constructor(
             )
         }
 
-    val isPrivacyEnabled = getSetting(Keys.PRIVACY_ENABLED, PRIVACY_ENABLED_DEFAULT)
-    val awayTimeoutSec = getSetting(Keys.AWAY_TIMEOUT, AWAY_TIMEOUT_DEFAULT)
-    val autoBackupAfterPasswordLogin =
-        getSetting(Keys.AUTO_BACKUP_AFTER_PASSWORD_LOGIN, AUTO_BACKUP_AFTER_PASSWORD_LOGIN_DEFAULT)
-    val passwordAfterXBiometricLogins =
-        getSetting(Keys.PASSWORD_AFTER_X_BIOMETRIC_LOGIN, PASSWORD_AFTER_X_BIOMETRIC_LOGIN_DEFAULT)
+    val isPrivacyEnabledFlow = getSetting(Keys.PRIVACY_ENABLED, PRIVACY_ENABLED_DEFAULT)
+    val awayTimeoutSecFlow = getSetting(Keys.AWAY_TIMEOUT, AWAY_TIMEOUT_DEFAULT)
 
+    suspend fun getPasswordAfterXBiometricLogins(): Int {
+        return getSetting(
+            Keys.PASSWORD_AFTER_X_BIOMETRIC_LOGIN,
+            PASSWORD_AFTER_X_BIOMETRIC_LOGIN_DEFAULT
+        ).first()
+    }
 
+    suspend fun getAutoBackupAfterPasswordLogin(): Boolean {
+        return getSetting(
+            Keys.AUTO_BACKUP_AFTER_PASSWORD_LOGIN,
+            AUTO_BACKUP_AFTER_PASSWORD_LOGIN_DEFAULT
+        ).first()
+    }
     suspend fun updatePrivacy(enabled: Boolean) {
         context.dataStore.edit { it[Keys.PRIVACY_ENABLED] = enabled }
     }

--- a/app/src/main/java/com/andryoga/safebox/data/repository/UserDetailsRepositoryImpl.kt
+++ b/app/src/main/java/com/andryoga/safebox/data/repository/UserDetailsRepositoryImpl.kt
@@ -7,7 +7,6 @@ import com.andryoga.safebox.data.db.secureDao.UserDetailsDaoSecure
 import com.andryoga.safebox.data.repository.interfaces.UserDetailsRepository
 import com.andryoga.safebox.providers.interfaces.PreferenceProvider
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import kotlinx.coroutines.flow.first
 import timber.log.Timber
 import java.util.Date
 import java.util.UUID
@@ -51,7 +50,7 @@ class UserDetailsRepositoryImpl @Inject constructor(
             max(0, currentBiometricLoginCountRemaining - 1)
         } else {
             // reset login count remaining after password login
-            settingsDataStore.passwordAfterXBiometricLogins.first()
+            settingsDataStore.getPasswordAfterXBiometricLogins()
         }
 
         preferenceProvider.upsertIntPref(

--- a/app/src/main/java/com/andryoga/safebox/ui/MainViewModel.kt
+++ b/app/src/main/java/com/andryoga/safebox/ui/MainViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -74,7 +73,15 @@ class MainViewModel @Inject constructor(
         initialValue = LoadingState.Initial
     )
 
-    val isPrivacyEnabled = settingsDataStore.isPrivacyEnabled
+    /**
+     * emits value only when user changes the setting from settings screen.
+     * It does not replay the last value.
+     * */
+    val isPrivacyEnabled = settingsDataStore.isPrivacyEnabledFlow.shareIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        replay = 0
+    )
 
     /**
      * A screen calls this to configure and show the top bar.

--- a/app/src/main/java/com/andryoga/safebox/ui/core/ActiveSessionManager.kt
+++ b/app/src/main/java/com/andryoga/safebox/ui/core/ActiveSessionManager.kt
@@ -34,7 +34,7 @@ class ActiveSessionManager @Inject constructor(
 
     init {
         applicationScope.launch {
-            settingsDataStore.awayTimeoutSec.collect {
+            settingsDataStore.awayTimeoutSecFlow.collect {
                 Timber.i("timeout updated in active session manager to $it seconds")
                 timeout = it.seconds
             }

--- a/app/src/test/java/com/andryoga/safebox/ui/MainViewModelTest.kt
+++ b/app/src/test/java/com/andryoga/safebox/ui/MainViewModelTest.kt
@@ -58,7 +58,7 @@ class MainViewModelTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        every { settingsDataStore.isPrivacyEnabled } returns isPrivacyEnabledFlow
+        every { settingsDataStore.isPrivacyEnabledFlow } returns isPrivacyEnabledFlow
         every { backupMetadataRepository.getBackupMetadata() } returns backupMetadataFlow
         every { activeSessionManager.logoutEvent } returns logoutEventFlow
 


### PR DESCRIPTION
## Description
* **Settings DataStore API Refinement**: The `SettingsDataStore` class has been refactored to provide more explicit ways of accessing settings. Some settings, like `passwordAfterXBiometricLogins` and `autoBackupAfterPasswordLogin`, are now exposed via `suspend` functions that return immediate values by calling `.first()` on their underlying flows. Other settings, such as `isPrivacyEnabled` and `awayTimeoutSec`, are still exposed as `Flow` properties but have been renamed with a `Flow` suffix (e.g., `isPrivacyEnabledFlow`) for clarity.
* **Optimized Settings Consumption**: Consumers of these settings, including `UserDetailsRepositoryImpl`, `LoginViewModel`, `ActiveSessionManager`, and `MainViewModel`, have been updated to utilize the new `suspend` functions for single-value retrieval or the renamed `Flow` properties for continuous observation. This change aims to reduce unnecessary flow collection when only the current value is needed.
* **LoginViewModel Simplification**: The `LoginViewModel` no longer maintains a `StateFlow` for `autoBackupAfterPasswordLogin`. Instead, it directly calls the new `settingsDataStore.getAutoBackupAfterPasswordLogin()` suspend function when checking whether to enqueue a backup request, simplifying its internal state management.
* **Test Suite Updates**: Corresponding unit tests for `MainViewModel` and `LoginViewModel` have been updated to reflect the changes in how settings are accessed and mocked, ensuring continued test coverage and correctness.

