### PR TITLE
updated AGP and other libs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.google.services)
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
@@ -68,10 +67,11 @@ android {
         }
     }
 
-    android.applicationVariants.configureEach { variant ->
-        variant.outputs.configureEach {
-            // if you are changing apk name then also change name in git workflow file
-            outputFileName = "SafeBox-${variant.name}.apk"
+    androidComponents {
+        onVariants(selector().all()) { variant ->
+            variant.outputs.each { output ->
+                output.outputFileName.set("SafeBox-${variant.name}.apk")
+            }
         }
     }
 
@@ -118,8 +118,8 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(17)
     }
     buildFeatures {
         compose true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ android {
     androidComponents {
         onVariants(selector().all()) { variant ->
             variant.outputs.each { output ->
+                // if you are changing apk name then also change name in git workflow file.
                 output.outputFileName.set("SafeBox-${variant.name}.apk")
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.serialization) apply false
 
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
 
     alias(libs.plugins.hilt) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,6 @@ android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
 # Reuse outputs from previous builds
 org.gradle.caching=true
 # Process modules in parallel

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-androidGradlePlugin = "8.13.2"
-kotlinGradlePlugin = "1.9.24"
+androidGradlePlugin = "9.0.0"
+kotlinGradlePlugin = "2.3.0"
 googleServicesGradlePlugin = "4.4.4"
 crashlyticsGradlePlugin = "3.0.6"
 detektGradlePlugin = "1.23.8"
@@ -16,7 +16,6 @@ truth = "1.4.5"
 composeBom = "2026.01.01"
 firebaseBom = "34.8.0"
 
-kotlin = "2.3.0"
 kotlinComposeCompiler = "2.3.0"
 ksp = "2.3.5"
 kotlinSerialization = "2.3.0"
@@ -26,7 +25,7 @@ lifecycleProcess = "2.10.0"
 activityCompose = "1.12.3"
 navigationCompose = "2.9.7"
 material3 = "1.4.0"
-daggerHilt = "2.58"
+daggerHilt = "2.59"
 androidxHilt = "1.3.0"
 work = "2.11.1"
 timber = "5.0.1"
@@ -118,7 +117,6 @@ android-application = { id = "com.android.application", version.ref = "androidGr
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesGradlePlugin" }
 crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlyticsGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinComposeCompiler" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektGradlePlugin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "daggerHilt" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Sat Aug 23 20:45:16 IST 2025
+#Sat Jan 31 16:05:47 IST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description
* **Android Gradle Plugin (AGP) Upgrade**: The Android Gradle Plugin has been significantly upgraded from version 8.13.2 to 9.0.0, bringing the project up to the latest major release.
* **Kotlin Gradle Plugin Upgrade**: The Kotlin Gradle Plugin has been updated from version 1.9.24 to 2.3.0, aligning with the latest Kotlin language features and build improvements.
* **Gradle Wrapper Update**: The Gradle wrapper has been updated to version 9.1.0, ensuring compatibility with the new AGP and Kotlin plugin versions.
* **Build Configuration Modernization**: Existing build configurations in `app/build.gradle` have been updated to use modern AGP DSLs, specifically for variant output naming and Kotlin JVM toolchain setup, replacing deprecated approaches.
* **Dependency Updates and Cleanup**: The Dagger Hilt dependency has been updated to version 2.59, and several deprecated or redundant plugin declarations (like `kotlin.android` and `android.nonFinalResIds`) have been removed from `build.gradle` files and `gradle.properties`.
