### PR TITLE
Fix nightly CI workflow by removing device matrix and hardcoding `pixel8Api34`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        device: [ pixel8Api34, pixel2Api24 ]
         shard: [ 0, 1, 2 ]
 
     steps:
@@ -51,12 +50,12 @@ jobs:
           $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "emulator"
 
       - name: Run Managed Device UI Tests (Debug Build)
-        run: ./gradlew ${{ matrix.device }}DebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.numShards=3 -Pandroid.testInstrumentationRunnerArguments.shardIndex=${{ matrix.shard }} --stacktrace
+        run: ./gradlew pixel8Api34DebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.numShards=3 -Pandroid.testInstrumentationRunnerArguments.shardIndex=${{ matrix.shard }} --stacktrace
 
       - name: Upload Test Reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: Test Reports (${{ matrix.device }} - Shard ${{ matrix.shard }} - Debug Build)
+          name: Test Reports (pixel8Api34 - Shard ${{ matrix.shard }} - Debug Build)
           path: |
             app/build/reports/androidTests/managedDevice/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,11 +148,6 @@ android {
                     apiLevel = 34
                     systemImageSource = "aosp-atd"
                 }
-                register("pixel2Api24") {
-                    device = "Pixel 2"
-                    apiLevel = 24
-                    systemImageSource = "aosp"
-                }
             }
         }
     }


### PR DESCRIPTION
### **User description**
## Description


___

### **PR Type**
Bug fix


___

### **Description**
- Remove device matrix from nightly workflow

- Hardcode UI test execution to `pixel8Api34`

- Update artifact upload step label


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Trigger["Nightly CI Trigger"] -- "Shards [0, 1, 2]" --> TestRun["Run pixel8Api34 UI Tests"]
  TestRun --> UploadArtifacts["Upload pixel8Api34 Test Reports"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nightly.yml</strong><dd><code>Restrict nightly UI test workflow execution to `pixel8Api34`</code></dd></summary>
<hr>

.github/workflows/nightly.yml

<ul><li>Remove the <code>device</code> matrix variable from the test strategy<br> <li> Explicitly invoke <code>pixel8Api34DebugAndroidTest</code> instead of using matrix <br>interpolation<br> <li> Update the artifact upload step name to reference <code>pixel8Api34</code> directly</ul>


</details>


  </td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/221/files#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

