### PR TITLE
Allow backup creation with any password and refine restore failure handling

### DIFF
--- a/app/src/androidTest/java/com/andryoga/safebox/ui/home/backupAndRestore/BackupAndRestoreScreenTest.kt
+++ b/app/src/androidTest/java/com/andryoga/safebox/ui/home/backupAndRestore/BackupAndRestoreScreenTest.kt
@@ -224,6 +224,23 @@ class BackupAndRestoreScreenTest {
     }
 
     @Test
+    fun dialogBodyText_inCorruptFileState_shouldRenderCorruptFileMessage() {
+        composeTestRule.setContent {
+            SafeBoxTheme {
+                dialogBodyText(
+                    operation = Operation.Restore(null),
+                    workflowState = WorkflowState.CORRUPT_FILE,
+                    password = "",
+                    onPasswordChange = {}
+                ).invoke()
+            }
+        }
+
+        composeTestRule.onNodeWithText(context.getString(R.string.restore_corrupt_file_message))
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun backupPathPermissionError_shouldDisplaySnackbarWithMessageAndRetryButton() {
         var retryClicked = false
         val snackbarHostState = androidx.compose.material3.SnackbarHostState()

--- a/app/src/androidTest/java/com/andryoga/safebox/ui/home/backupAndRestore/BackupAndRestoreWorkersTest.kt
+++ b/app/src/androidTest/java/com/andryoga/safebox/ui/home/backupAndRestore/BackupAndRestoreWorkersTest.kt
@@ -19,6 +19,7 @@ import com.andryoga.safebox.domain.models.record.LoginData
 import com.andryoga.safebox.domain.models.record.NoteData
 import com.andryoga.safebox.e2e.E2ETestUtils
 import com.andryoga.safebox.security.interfaces.SymmetricKeyUtils
+import com.andryoga.safebox.ui.home.backupAndRestore.components.newBackupOrRestore.RestoreFailureReason
 import com.andryoga.safebox.worker.BackupDataWorker
 import com.andryoga.safebox.worker.RestoreDataWorker
 import com.andryoga.safebox.worker.SafeBoxWorkerFactory
@@ -254,7 +255,9 @@ class BackupAndRestoreWorkersTest {
                 .build()
 
             val result = restoreWorker.doWork()
-            assertThat(result).isEqualTo(Result.failure())
+            assertThat(result).isEqualTo(Result.failure(RestoreFailureReason.INCORRECT_PASSWORD.toWorkData()))
+            assertThat(RestoreFailureReason.fromWorkData(result.outputData))
+                .isEqualTo(RestoreFailureReason.INCORRECT_PASSWORD)
             assertThat(loginDataRepository.getAllLoginData().first().isEmpty()).isTrue()
         }
 
@@ -285,7 +288,9 @@ class BackupAndRestoreWorkersTest {
                 .build()
 
             val result = restoreWorker.doWork()
-            assertThat(result).isEqualTo(Result.failure())
+            assertThat(result).isEqualTo(Result.failure(RestoreFailureReason.CORRUPT_OR_INVALID_FILE.toWorkData()))
+            assertThat(RestoreFailureReason.fromWorkData(result.outputData))
+                .isEqualTo(RestoreFailureReason.CORRUPT_OR_INVALID_FILE)
         }
 
     @Test

--- a/app/src/main/java/com/andryoga/safebox/common/AnalyticsKey.kt
+++ b/app/src/main/java/com/andryoga/safebox/common/AnalyticsKey.kt
@@ -9,6 +9,7 @@ enum class AnalyticsKey(val eventName: String) {
     OPEN_GITHUB("open_github"),
     OPEN_PLAY_STORE("open_play_store"),
     EMAIL_FEEDBACK("email_feedback"),
+    BACKUP_STARTED("backup_started"),
     BACKUP_SELECT_DIR_RESULT("backup_select_dir_result"),
     BACKUP_DATA_SUCCESS("backup_data_success"),
     BACKUP_DATA_FAILURE("backup_data_failure"),

--- a/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreScreen.kt
+++ b/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreScreen.kt
@@ -131,7 +131,8 @@ private fun dialogIconComposable(
                 tint = MaterialTheme.colorScheme.primary
             )
 
-            WorkflowState.FAILED -> Icon(
+            WorkflowState.FAILED,
+            WorkflowState.CORRUPT_FILE -> Icon(
                 Icons.Filled.ErrorOutline,
                 contentDescription = null,
                 modifier = modifier,
@@ -147,10 +148,14 @@ private fun cancelButtonComposable(
     onDismiss: () -> Unit
 ): @Composable (() -> Unit) {
     return when (workflowState) {
-        WorkflowState.WRONG_PASSWORD, WorkflowState.FAILED, WorkflowState.ASK_FOR_PASSWORD, WorkflowState.SUCCESS -> {
+        WorkflowState.WRONG_PASSWORD,
+        WorkflowState.FAILED,
+        WorkflowState.CORRUPT_FILE,
+        WorkflowState.ASK_FOR_PASSWORD,
+        WorkflowState.SUCCESS -> {
             {
                 val textResId = when (workflowState) {
-                    WorkflowState.SUCCESS, WorkflowState.FAILED -> R.string.common_ok
+                    WorkflowState.SUCCESS, WorkflowState.FAILED, WorkflowState.CORRUPT_FILE -> R.string.common_ok
                     else -> R.string.common_cancel
                 }
 
@@ -210,6 +215,15 @@ fun dialogBodyText(
                     workflowState = workflowState,
                     password = password,
                     onPasswordChange = onPasswordChange
+                )
+            }
+        }
+
+        WorkflowState.CORRUPT_FILE -> {
+            {
+                Text(
+                    text = stringResource(R.string.restore_corrupt_file_message),
+                    fontWeight = FontWeight.Medium
                 )
             }
         }

--- a/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreVM.kt
+++ b/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreVM.kt
@@ -10,7 +10,6 @@ import androidx.work.WorkManager
 import com.andryoga.safebox.analytics.AnalyticsHelper
 import com.andryoga.safebox.common.AnalyticsKey
 import com.andryoga.safebox.common.CommonConstants
-import com.andryoga.safebox.data.repository.interfaces.UserDetailsRepository
 import com.andryoga.safebox.di.IsDebug
 import com.andryoga.safebox.security.interfaces.SymmetricKeyUtils
 import com.andryoga.safebox.ui.core.InAppReviewManager
@@ -32,7 +31,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class NewBackupOrRestoreVM @Inject constructor(
-    private val userDetailsRepository: UserDetailsRepository,
     private val workManager: WorkManager,
     private val symmetricKeyUtils: SymmetricKeyUtils,
     private val analyticsHelper: AnalyticsHelper,
@@ -70,46 +68,42 @@ class NewBackupOrRestoreVM @Inject constructor(
 
     private fun handlePasswordConfirmedAction(password: String) {
         viewModelScope.launch {
-            val isPasswordCheckRequired = operation == Operation.Backup
-
-            var isPswrdCorrect = false
-            if (isPasswordCheckRequired) {
-                isPswrdCorrect = userDetailsRepository.checkPassword(password)
-                if (isPswrdCorrect.not()) {
-                    updateWorkflowState(WorkflowState.WRONG_PASSWORD)
-                    return@launch
+            when (operation) {
+                Operation.Backup -> {
+                    Timber.i("password confirmed for new backup")
+                    analyticsHelper.logEvent(AnalyticsKey.BACKUP_STARTED)
                 }
-            } else {
-                // password check is not required for restore
-                analyticsHelper.logEvent(AnalyticsKey.RESTORE_STARTED)
+
+                is Operation.Restore -> {
+                    Timber.i("password confirmed for new restore")
+                    analyticsHelper.logEvent(AnalyticsKey.RESTORE_STARTED)
+                }
             }
 
-            if (isPasswordCheckRequired.not() || isPswrdCorrect) {
-                Timber.i("enqueuing work req")
-                val requestId = enqueueWorkRequest(password, operation)
-                workManager.getWorkInfoByIdFlow(requestId).onEach { workInfo ->
-                    Timber.i("backup/restore work state: ${workInfo?.state}")
-                    when (workInfo?.state) {
-                        WorkInfo.State.ENQUEUED, WorkInfo.State.RUNNING -> updateWorkflowState(
-                            WorkflowState.IN_PROGRESS
-                        )
+            Timber.i("enqueuing work req")
+            val requestId = enqueueWorkRequest(password, operation)
+            workManager.getWorkInfoByIdFlow(requestId).onEach { workInfo ->
+                Timber.i("backup/restore work state: ${workInfo?.state}")
+                when (workInfo?.state) {
+                    WorkInfo.State.ENQUEUED, WorkInfo.State.RUNNING -> updateWorkflowState(
+                        WorkflowState.IN_PROGRESS
+                    )
 
-                        WorkInfo.State.SUCCEEDED -> {
-                            if (operation is Operation.Restore) {
-                                _startReviewOnRestoreSuccess.send(Unit)
-                            }
-                            updateWorkflowState(
-                                WorkflowState.SUCCESS
-                            )
+                    WorkInfo.State.SUCCEEDED -> {
+                        if (operation is Operation.Restore) {
+                            _startReviewOnRestoreSuccess.send(Unit)
                         }
-
-                        WorkInfo.State.FAILED, WorkInfo.State.BLOCKED, WorkInfo.State.CANCELLED, null -> updateWorkflowState(
-                            WorkflowState.FAILED
+                        updateWorkflowState(
+                            WorkflowState.SUCCESS
                         )
-
                     }
-                }.launchIn(viewModelScope)
-            }
+
+                    WorkInfo.State.FAILED, WorkInfo.State.BLOCKED, WorkInfo.State.CANCELLED, null -> updateWorkflowState(
+                        WorkflowState.FAILED
+                    )
+
+                }
+            }.launchIn(viewModelScope)
         }
     }
 

--- a/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreVM.kt
+++ b/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreVM.kt
@@ -98,9 +98,19 @@ class NewBackupOrRestoreVM @Inject constructor(
                         )
                     }
 
-                    WorkInfo.State.FAILED, WorkInfo.State.BLOCKED, WorkInfo.State.CANCELLED, null -> updateWorkflowState(
-                        WorkflowState.FAILED
-                    )
+                    WorkInfo.State.FAILED, WorkInfo.State.BLOCKED, WorkInfo.State.CANCELLED, null -> {
+                        val targetState =
+                            if (operation is Operation.Restore && workInfo?.state == WorkInfo.State.FAILED) {
+                                when (RestoreFailureReason.fromWorkData(workInfo.outputData)) {
+                                    RestoreFailureReason.INCORRECT_PASSWORD -> WorkflowState.WRONG_PASSWORD
+                                    RestoreFailureReason.CORRUPT_OR_INVALID_FILE -> WorkflowState.CORRUPT_FILE
+                                    RestoreFailureReason.UNKNOWN_ERROR -> WorkflowState.FAILED
+                                }
+                            } else {
+                                WorkflowState.FAILED
+                            }
+                        updateWorkflowState(targetState)
+                    }
 
                 }
             }.launchIn(viewModelScope)

--- a/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/RestoreFailureReason.kt
+++ b/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/RestoreFailureReason.kt
@@ -1,0 +1,31 @@
+package com.andryoga.safebox.ui.home.backupAndRestore.components.newBackupOrRestore
+
+import androidx.work.Data
+import androidx.work.workDataOf
+
+/**
+ * Type-safe failure reasons emitted by [com.andryoga.safebox.worker.RestoreDataWorker]
+ * in output data to communicate failure causes to the UI layer.
+ */
+enum class RestoreFailureReason {
+    // Decryption failed due to an incorrect master password.
+    INCORRECT_PASSWORD,
+
+    // Backup file could not be read, parsed, or contains corrupted/invalid data structure.
+    CORRUPT_OR_INVALID_FILE,
+
+    // An unclassified or unexpected error occurred during the restore operation.
+    UNKNOWN_ERROR;
+
+    fun toWorkData(): Data = workDataOf(KEY_RESTORE_FAILURE_REASON to ordinal)
+
+    companion object {
+        private const val KEY_RESTORE_FAILURE_REASON = "key_restore_failure_reason"
+
+        fun fromWorkData(data: Data?): RestoreFailureReason {
+            if (data == null) return UNKNOWN_ERROR
+            val ordinal = data.getInt(KEY_RESTORE_FAILURE_REASON, -1)
+            return entries.getOrElse(ordinal) { UNKNOWN_ERROR }
+        }
+    }
+}

--- a/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/ScreenState.kt
+++ b/app/src/main/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/ScreenState.kt
@@ -14,6 +14,9 @@ enum class WorkflowState {
     // incorrect password entered by the user. show error.
     WRONG_PASSWORD,
 
+    // selected backup file is corrupted or has an invalid structure.
+    CORRUPT_FILE,
+
     // backup/restore job is in progress
     IN_PROGRESS,
 

--- a/app/src/main/java/com/andryoga/safebox/worker/BackupDataWorker.kt
+++ b/app/src/main/java/com/andryoga/safebox/worker/BackupDataWorker.kt
@@ -157,7 +157,12 @@ class BackupDataWorker
             isSuccess = false
         }
 
-        return if (isSuccess) Result.success() else Result.failure()
+        if (isSuccess) {
+            analyticsHelper.logEvent(AnalyticsKey.BACKUP_DATA_SUCCESS)
+            return Result.success()
+        } else {
+            return Result.failure()
+        }
     }
 
     private fun sendNotification(notificationOptions: NotificationOptions) {

--- a/app/src/main/java/com/andryoga/safebox/worker/RestoreDataWorker.kt
+++ b/app/src/main/java/com/andryoga/safebox/worker/RestoreDataWorker.kt
@@ -25,20 +25,27 @@ import com.andryoga.safebox.data.db.secureDao.LoginDataDaoSecure
 import com.andryoga.safebox.data.db.secureDao.SecureNoteDataDaoSecure
 import com.andryoga.safebox.security.interfaces.PasswordBasedEncryption
 import com.andryoga.safebox.security.interfaces.SymmetricKeyUtils
+import com.andryoga.safebox.ui.home.backupAndRestore.components.newBackupOrRestore.RestoreFailureReason
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream
+import java.io.IOException
 import java.io.InvalidClassException
 import java.io.InvalidObjectException
 import java.io.ObjectInputStream
 import java.io.ObjectStreamClass
+import java.nio.BufferUnderflowException
 import java.nio.ByteBuffer
+import java.security.GeneralSecurityException
 import java.util.Date
+import javax.crypto.AEADBadTagException
 import javax.crypto.BadPaddingException
+import javax.crypto.IllegalBlockSizeException
 
 @HiltWorker
 class RestoreDataWorker
@@ -146,10 +153,30 @@ class RestoreDataWorker
             analyticsHelper.logEvent(AnalyticsKey.RESTORE_DATA_WRONG_PASSWORD) {
                 param(AnalyticsParam.VERSION, version)
             }
-            Result.failure()
+            Result.failure(RestoreFailureReason.INCORRECT_PASSWORD.toWorkData())
         } catch (exception: Exception) {
             onRestoreError(exception)
-            Result.failure()
+            val failureReason = mapExceptionToFailureReason(exception)
+            Result.failure(failureReason.toWorkData())
+        }
+    }
+
+    private fun mapExceptionToFailureReason(exception: Exception): RestoreFailureReason {
+        return when (exception) {
+            is IOException,
+            is InvalidClassException,
+            is InvalidObjectException,
+            is IllegalArgumentException,
+            is IllegalStateException,
+            is NullPointerException,
+            is ClassCastException,
+            is BufferUnderflowException,
+            is IllegalBlockSizeException,
+            is AEADBadTagException,
+            is GeneralSecurityException,
+            is SerializationException -> RestoreFailureReason.CORRUPT_OR_INVALID_FILE
+
+            else -> RestoreFailureReason.UNKNOWN_ERROR
         }
     }
 

--- a/app/src/main/java/com/andryoga/safebox/worker/RestoreDataWorker.kt
+++ b/app/src/main/java/com/andryoga/safebox/worker/RestoreDataWorker.kt
@@ -28,7 +28,6 @@ import com.andryoga.safebox.security.interfaces.SymmetricKeyUtils
 import com.andryoga.safebox.ui.home.backupAndRestore.components.newBackupOrRestore.RestoreFailureReason
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import timber.log.Timber
@@ -43,7 +42,6 @@ import java.nio.BufferUnderflowException
 import java.nio.ByteBuffer
 import java.security.GeneralSecurityException
 import java.util.Date
-import javax.crypto.AEADBadTagException
 import javax.crypto.BadPaddingException
 import javax.crypto.IllegalBlockSizeException
 
@@ -164,17 +162,13 @@ class RestoreDataWorker
     private fun mapExceptionToFailureReason(exception: Exception): RestoreFailureReason {
         return when (exception) {
             is IOException,
-            is InvalidClassException,
-            is InvalidObjectException,
             is IllegalArgumentException,
             is IllegalStateException,
             is NullPointerException,
             is ClassCastException,
             is BufferUnderflowException,
             is IllegalBlockSizeException,
-            is AEADBadTagException,
-            is GeneralSecurityException,
-            is SerializationException -> RestoreFailureReason.CORRUPT_OR_INVALID_FILE
+            is GeneralSecurityException -> RestoreFailureReason.CORRUPT_OR_INVALID_FILE
 
             else -> RestoreFailureReason.UNKNOWN_ERROR
         }

--- a/app/src/main/java/com/andryoga/safebox/worker/RestoreDataWorker.kt
+++ b/app/src/main/java/com/andryoga/safebox/worker/RestoreDataWorker.kt
@@ -143,7 +143,7 @@ class RestoreDataWorker
                 if (::importMap.isInitialized) importMap[CommonConstants.VERSION_KEY]!![0].toInt()
                     .toDouble() else 0.0
             }.getOrNull() ?: 0.0
-            analyticsHelper.logEvent(AnalyticsKey.RESTORE_DATA_FAILURE) {
+            analyticsHelper.logEvent(AnalyticsKey.RESTORE_DATA_WRONG_PASSWORD) {
                 param(AnalyticsParam.VERSION, version)
             }
             Result.failure()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,7 +66,7 @@
 
     <!--     restore-->
     <string name="restore">Restore</string>
-    <string name="restore_info">"Click below button to select a backup file.\nPlease note that to restore data, you have to enter the same master password that was used to make the backup file."</string>
+    <string name="restore_info">"Click below button to select a backup file.\nPlease note that to restore data, enter the same password that was used to create the backup file."</string>
     <string name="new_restore_dialog_body_text">Please enter the password that was used to make the backup file.</string>
     <string name="restore_complete_message">Data has been successfully restored.</string>
     <string name="restore_in_progress_message">It may take a while to restore data. Sit back and relax !</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,10 +58,10 @@
     <string name="backup_path_select_failed_message">Could not access the selected folder. Try creating a new folder for your backups.</string>
     <string name="retry">Retry</string>
     <string name="backup_time">Backup was last taken on %1$s</string>
-    <string name="backup_info_1">* Backup file is encrypted by your current master password\n* Backup is taken every time you login with password</string>
+    <string name="backup_info_1">* Backup is taken every time you login with password and is encrypted by your current master password </string>
     <string name="backup_edit_path">Edit Path</string>
-    <string name="new_backup_dialog_body_text">Please enter your current master password to create a new backup file.</string>
-    <string name="backup_in_progress_message">It may take a while to backup data. Sit back and relax !</string>
+    <string name="new_backup_dialog_body_text">Please enter a password to create a new backup file.</string>
+    <string name="backup_in_progress_message">It may take a while to back up data. Sit back and relax !</string>
     <string name="backup_complete_message">Your backup is complete! It is protected by your current password.</string>
 
     <!--     restore-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="backup_edit_path">Edit Path</string>
     <string name="new_backup_dialog_body_text">Please enter a password to create a new backup file.</string>
     <string name="backup_in_progress_message">It may take a while to back up data. Sit back and relax !</string>
-    <string name="backup_complete_message">Your backup is complete! It is protected by your current password.</string>
+    <string name="backup_complete_message">Your backup is complete! Remember the password.</string>
 
     <!--     restore-->
     <string name="restore">Restore</string>
@@ -73,7 +73,8 @@
 
     <!--     master password dialog-->
     <string name="incorrect_pswrd_message">Password is incorrect !</string>
-    <string name="failed_message">Something went wrong! Please try again later.</string>
+    <string name="restore_corrupt_file_message">The selected backup file is corrupted or invalid. Please choose a valid backup file.</string>
+    <string name="failed_message">An unexpected error occurred while processing your data.</string>
 
     <!--    Notification-->
     <string name="notification_backup_channel_id">backup data safebox</string>

--- a/app/src/test/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreVMTest.kt
+++ b/app/src/test/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreVMTest.kt
@@ -259,7 +259,65 @@ class NewBackupOrRestoreVMTest {
         }
 
     @Test
-    fun `when workInfo transitions to FAILED, workflowState updates to FAILED`() = runTest {
+    fun `when workInfo transitions to FAILED on Restore with INCORRECT_PASSWORD, workflowState updates to WRONG_PASSWORD`() =
+        runTest {
+            val fileUri: Uri = mockk(relaxed = true)
+            viewModel.initVM(Operation.Restore(fileUri))
+            val mockWorkInfo: WorkInfo = mockk {
+                every { state } returns WorkInfo.State.FAILED
+                every { outputData } returns RestoreFailureReason.INCORRECT_PASSWORD.toWorkData()
+            }
+            workInfoFlow.value = mockWorkInfo
+
+            viewModel.onScreenAction(ScreenAction.PasswordConfirmed("password"))
+            advanceUntilIdle()
+
+            viewModel.uiState.test {
+                assertThat(awaitItem().workflowState).isEqualTo(WorkflowState.WRONG_PASSWORD)
+            }
+        }
+
+    @Test
+    fun `when workInfo transitions to FAILED on Restore with CORRUPT_OR_INVALID_FILE, workflowState updates to CORRUPT_FILE`() =
+        runTest {
+            val fileUri: Uri = mockk(relaxed = true)
+            viewModel.initVM(Operation.Restore(fileUri))
+            val mockWorkInfo: WorkInfo = mockk {
+                every { state } returns WorkInfo.State.FAILED
+                every { outputData } returns RestoreFailureReason.CORRUPT_OR_INVALID_FILE.toWorkData()
+            }
+            workInfoFlow.value = mockWorkInfo
+
+            viewModel.onScreenAction(ScreenAction.PasswordConfirmed("password"))
+            advanceUntilIdle()
+
+            viewModel.uiState.test {
+                assertThat(awaitItem().workflowState).isEqualTo(WorkflowState.CORRUPT_FILE)
+            }
+        }
+
+    @Test
+    fun `when workInfo transitions to FAILED on Restore with UNKNOWN_ERROR, workflowState updates to FAILED`() =
+        runTest {
+            val fileUri: Uri = mockk(relaxed = true)
+            viewModel.initVM(Operation.Restore(fileUri))
+            val mockWorkInfo: WorkInfo = mockk {
+                every { state } returns WorkInfo.State.FAILED
+                every { outputData } returns RestoreFailureReason.UNKNOWN_ERROR.toWorkData()
+            }
+            workInfoFlow.value = mockWorkInfo
+
+            viewModel.onScreenAction(ScreenAction.PasswordConfirmed("password"))
+            advanceUntilIdle()
+
+            viewModel.uiState.test {
+                assertThat(awaitItem().workflowState).isEqualTo(WorkflowState.FAILED)
+            }
+        }
+
+    @Test
+    fun `when workInfo transitions to FAILED on Backup, workflowState updates to FAILED`() =
+        runTest {
         viewModel.initVM(Operation.Backup)
         val mockWorkInfo: WorkInfo = mockk { every { state } returns WorkInfo.State.FAILED }
         workInfoFlow.value = mockWorkInfo

--- a/app/src/test/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreVMTest.kt
+++ b/app/src/test/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/NewBackupOrRestoreVMTest.kt
@@ -14,14 +14,11 @@ import com.andryoga.safebox.common.AnalyticsKey
 import com.andryoga.safebox.common.CommonConstants
 import com.andryoga.safebox.common.CommonConstants.BACKUP_PARAM_IS_SHOW_START_NOTIFICATION
 import com.andryoga.safebox.common.CommonConstants.BACKUP_PARAM_PASSWORD
-import com.andryoga.safebox.data.repository.interfaces.UserDetailsRepository
 import com.andryoga.safebox.security.interfaces.SymmetricKeyUtils
 import com.andryoga.safebox.ui.core.InAppReviewManager
 import com.google.common.truth.Truth.assertThat
 import dagger.Lazy
 import io.mockk.MockKAnnotations
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockk
@@ -52,9 +49,6 @@ class NewBackupOrRestoreVMTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @RelaxedMockK
-    lateinit var userDetailsRepository: UserDetailsRepository
-
-    @RelaxedMockK
     lateinit var workManager: WorkManager
 
     @RelaxedMockK
@@ -79,7 +73,6 @@ class NewBackupOrRestoreVMTest {
         every { workManager.getWorkInfoByIdFlow(any()) } returns workInfoFlow
 
         viewModel = NewBackupOrRestoreVM(
-            userDetailsRepository,
             workManager,
             symmetricKeyUtils,
             analyticsHelper,
@@ -99,7 +92,6 @@ class NewBackupOrRestoreVMTest {
     @Test
     fun initialUiState_whenIsDebugFalse_defaultPasswordShouldBeEmpty() = runTest {
         val prodViewModel = NewBackupOrRestoreVM(
-            userDetailsRepository,
             workManager,
             symmetricKeyUtils,
             analyticsHelper,
@@ -135,33 +127,11 @@ class NewBackupOrRestoreVMTest {
     }
 
     @Test
-    fun `PasswordConfirmed on Backup with incorrect password updates workflowState to WRONG_PASSWORD and does not enqueue work`() =
+    fun `PasswordConfirmed on Backup with any password logs BACKUP_STARTED and enqueues BackupDataWorker`() =
         runTest {
             viewModel.initVM(Operation.Backup)
-            val password = "wrong_password"
-            coEvery { userDetailsRepository.checkPassword(password) } returns false
-
-            viewModel.onScreenAction(ScreenAction.PasswordConfirmed(password))
-            advanceUntilIdle()
-
-            viewModel.uiState.test {
-                assertThat(awaitItem().workflowState).isEqualTo(WorkflowState.WRONG_PASSWORD)
-            }
-            verify(exactly = 0) {
-                workManager.enqueueUniqueWork(
-                    any(),
-                    any(),
-                    any<OneTimeWorkRequest>()
-                )
-            }
-        }
-
-    @Test
-    fun `PasswordConfirmed on Backup with correct password enqueues BackupDataWorker`() = runTest {
-        viewModel.initVM(Operation.Backup)
-        val password = "correct_password"
-        val encryptedPassword = "encrypted_correct_password"
-        coEvery { userDetailsRepository.checkPassword(password) } returns true
+            val password = "any_password"
+            val encryptedPassword = "encrypted_any_password"
         every { symmetricKeyUtils.encrypt(password) } returns encryptedPassword
 
         val workRequestSlot = slot<OneTimeWorkRequest>()
@@ -176,6 +146,7 @@ class NewBackupOrRestoreVMTest {
         viewModel.onScreenAction(ScreenAction.PasswordConfirmed(password))
         advanceUntilIdle()
 
+            verify { analyticsHelper.logEvent(AnalyticsKey.BACKUP_STARTED) }
         verify {
             workManager.enqueueUniqueWork(
                 CommonConstants.WORKER_NAME_BACKUP_DATA,
@@ -189,7 +160,7 @@ class NewBackupOrRestoreVMTest {
     }
 
     @Test
-    fun `PasswordConfirmed on Restore skips checkPassword, logs RESTORE_STARTED, and enqueues RestoreDataWorker with encrypted password and fileUri`() =
+    fun `PasswordConfirmed on Restore logs RESTORE_STARTED and enqueues RestoreDataWorker with encrypted password and fileUri`() =
         runTest {
             val fileUri: Uri = mockk(relaxed = true)
             viewModel.initVM(Operation.Restore(fileUri))
@@ -209,7 +180,6 @@ class NewBackupOrRestoreVMTest {
             viewModel.onScreenAction(ScreenAction.PasswordConfirmed(password))
             advanceUntilIdle()
 
-            coVerify(exactly = 0) { userDetailsRepository.checkPassword(any()) }
             verify { analyticsHelper.logEvent(AnalyticsKey.RESTORE_STARTED) }
             verify {
                 workManager.enqueueUniqueWork(
@@ -231,7 +201,6 @@ class NewBackupOrRestoreVMTest {
     @Test
     fun `when workInfo transitions to ENQUEUED, workflowState updates to IN_PROGRESS`() = runTest {
         viewModel.initVM(Operation.Backup)
-        coEvery { userDetailsRepository.checkPassword(any()) } returns true
         val mockWorkInfo: WorkInfo = mockk { every { state } returns WorkInfo.State.ENQUEUED }
         workInfoFlow.value = mockWorkInfo
 
@@ -246,7 +215,6 @@ class NewBackupOrRestoreVMTest {
     @Test
     fun `when workInfo transitions to RUNNING, workflowState updates to IN_PROGRESS`() = runTest {
         viewModel.initVM(Operation.Backup)
-        coEvery { userDetailsRepository.checkPassword(any()) } returns true
         val mockWorkInfo: WorkInfo = mockk { every { state } returns WorkInfo.State.RUNNING }
         workInfoFlow.value = mockWorkInfo
 
@@ -262,7 +230,6 @@ class NewBackupOrRestoreVMTest {
     fun `when workInfo transitions to SUCCEEDED on Backup, workflowState updates to SUCCESS and no review event emitted`() =
         runTest {
             viewModel.initVM(Operation.Backup)
-            coEvery { userDetailsRepository.checkPassword(any()) } returns true
             val mockWorkInfo: WorkInfo = mockk { every { state } returns WorkInfo.State.SUCCEEDED }
             workInfoFlow.value = mockWorkInfo
 
@@ -294,7 +261,6 @@ class NewBackupOrRestoreVMTest {
     @Test
     fun `when workInfo transitions to FAILED, workflowState updates to FAILED`() = runTest {
         viewModel.initVM(Operation.Backup)
-        coEvery { userDetailsRepository.checkPassword(any()) } returns true
         val mockWorkInfo: WorkInfo = mockk { every { state } returns WorkInfo.State.FAILED }
         workInfoFlow.value = mockWorkInfo
 
@@ -309,7 +275,6 @@ class NewBackupOrRestoreVMTest {
     @Test
     fun `when workInfo transitions to BLOCKED, workflowState updates to FAILED`() = runTest {
         viewModel.initVM(Operation.Backup)
-        coEvery { userDetailsRepository.checkPassword(any()) } returns true
         val mockWorkInfo: WorkInfo = mockk { every { state } returns WorkInfo.State.BLOCKED }
         workInfoFlow.value = mockWorkInfo
 
@@ -324,7 +289,6 @@ class NewBackupOrRestoreVMTest {
     @Test
     fun `when workInfo transitions to CANCELLED, workflowState updates to FAILED`() = runTest {
         viewModel.initVM(Operation.Backup)
-        coEvery { userDetailsRepository.checkPassword(any()) } returns true
         val mockWorkInfo: WorkInfo = mockk { every { state } returns WorkInfo.State.CANCELLED }
         workInfoFlow.value = mockWorkInfo
 
@@ -339,7 +303,6 @@ class NewBackupOrRestoreVMTest {
     @Test
     fun `when workInfo is null, workflowState updates to FAILED`() = runTest {
         viewModel.initVM(Operation.Backup)
-        coEvery { userDetailsRepository.checkPassword(any()) } returns true
         workInfoFlow.value = null
 
         viewModel.onScreenAction(ScreenAction.PasswordConfirmed("password"))

--- a/app/src/test/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/RestoreFailureReasonTest.kt
+++ b/app/src/test/java/com/andryoga/safebox/ui/home/backupAndRestore/components/newBackupOrRestore/RestoreFailureReasonTest.kt
@@ -1,0 +1,38 @@
+package com.andryoga.safebox.ui.home.backupAndRestore.components.newBackupOrRestore
+
+import androidx.work.Data
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RestoreFailureReasonTest {
+
+    @Test
+    fun toWorkData_fromWorkData_roundTrip_shouldPreserveEnumValues() {
+        RestoreFailureReason.entries.forEach { reason ->
+            val workData = reason.toWorkData()
+            val parsedReason = RestoreFailureReason.fromWorkData(workData)
+            assertThat(parsedReason).isEqualTo(reason)
+        }
+    }
+
+    @Test
+    fun fromWorkData_nullData_shouldReturnUnknownError() {
+        val result = RestoreFailureReason.fromWorkData(null)
+        assertThat(result).isEqualTo(RestoreFailureReason.UNKNOWN_ERROR)
+    }
+
+    @Test
+    fun fromWorkData_emptyData_shouldReturnUnknownError() {
+        val result = RestoreFailureReason.fromWorkData(Data.EMPTY)
+        assertThat(result).isEqualTo(RestoreFailureReason.UNKNOWN_ERROR)
+    }
+
+    @Test
+    fun fromWorkData_outOfRangeOrdinal_shouldReturnUnknownError() {
+        val data = Data.Builder()
+            .putInt("key_restore_failure_reason", 999)
+            .build()
+        val result = RestoreFailureReason.fromWorkData(data)
+        assertThat(result).isEqualTo(RestoreFailureReason.UNKNOWN_ERROR)
+    }
+}

--- a/app/src/test/java/com/andryoga/safebox/worker/BackupDataWorkerTest.kt
+++ b/app/src/test/java/com/andryoga/safebox/worker/BackupDataWorkerTest.kt
@@ -182,6 +182,7 @@ class BackupDataWorkerTest {
         val result = worker.doWork()
 
         assertThat(result).isEqualTo(Result.success())
+        assertThat(analyticsHelper.hasLogged(AnalyticsKey.BACKUP_DATA_SUCCESS)).isTrue()
         assertThat(fakeBackupMetadataRepo.updatedDate).isNull()
 
         val createdFiles =
@@ -220,6 +221,7 @@ class BackupDataWorkerTest {
         val result = worker.doWork()
 
         assertThat(result).isEqualTo(Result.success())
+        assertThat(analyticsHelper.hasLogged(AnalyticsKey.BACKUP_DATA_SUCCESS)).isTrue()
         assertThat(fakeBackupMetadataRepo.updatedDate).isNotNull()
 
         val createdFiles = tempDir.listFiles { f -> f.name.startsWith("SafeBoxBackup") }
@@ -282,6 +284,7 @@ class BackupDataWorkerTest {
         val result = worker.doWork()
 
         assertThat(result).isEqualTo(Result.success())
+        assertThat(analyticsHelper.hasLogged(AnalyticsKey.BACKUP_DATA_SUCCESS)).isTrue()
 
         val oldestFile = File(tempDir, "SafeBoxBackup20260101000000001.bak")
         assertThat(oldestFile.exists()).isFalse()

--- a/app/src/test/java/com/andryoga/safebox/worker/RestoreDataWorkerTest.kt
+++ b/app/src/test/java/com/andryoga/safebox/worker/RestoreDataWorkerTest.kt
@@ -20,6 +20,7 @@ import com.andryoga.safebox.data.db.secureDao.SecureNoteDataDaoSecure
 import com.andryoga.safebox.security.interfaces.PasswordBasedEncryption
 import com.andryoga.safebox.security.interfaces.SymmetricKeyUtils
 import com.andryoga.safebox.test.fakes.FakeAnalyticsHelper
+import com.andryoga.safebox.ui.home.backupAndRestore.components.newBackupOrRestore.RestoreFailureReason
 import com.google.common.truth.Truth.assertThat
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -200,7 +201,9 @@ class RestoreDataWorkerTest {
         val worker = buildWorker(inputData)
         val result = worker.doWork()
 
-        assertThat(result).isEqualTo(Result.failure())
+        assertThat(result).isEqualTo(Result.failure(RestoreFailureReason.INCORRECT_PASSWORD.toWorkData()))
+        assertThat(RestoreFailureReason.fromWorkData(result.outputData))
+            .isEqualTo(RestoreFailureReason.INCORRECT_PASSWORD)
         assertThat(analyticsHelper.hasLogged(AnalyticsKey.RESTORE_DATA_WRONG_PASSWORD)).isTrue()
         assertThat(analyticsHelper.hasLogged(AnalyticsKey.RESTORE_DATA_FAILURE)).isFalse()
     }
@@ -220,7 +223,9 @@ class RestoreDataWorkerTest {
         val worker = buildWorker(inputData)
         val result = worker.doWork()
 
-        assertThat(result).isEqualTo(Result.failure())
+        assertThat(result).isEqualTo(Result.failure(RestoreFailureReason.CORRUPT_OR_INVALID_FILE.toWorkData()))
+        assertThat(RestoreFailureReason.fromWorkData(result.outputData))
+            .isEqualTo(RestoreFailureReason.CORRUPT_OR_INVALID_FILE)
         assertThat(analyticsHelper.hasLogged(AnalyticsKey.RESTORE_DATA_FAILURE)).isTrue()
     }
 
@@ -229,7 +234,9 @@ class RestoreDataWorkerTest {
         val worker = buildWorker(Data.EMPTY)
         val result = worker.doWork()
 
-        assertThat(result).isEqualTo(Result.failure())
+        assertThat(result).isEqualTo(Result.failure(RestoreFailureReason.CORRUPT_OR_INVALID_FILE.toWorkData()))
+        assertThat(RestoreFailureReason.fromWorkData(result.outputData))
+            .isEqualTo(RestoreFailureReason.CORRUPT_OR_INVALID_FILE)
         assertThat(analyticsHelper.hasLogged(AnalyticsKey.RESTORE_DATA_FAILURE)).isTrue()
     }
 }

--- a/app/src/test/java/com/andryoga/safebox/worker/RestoreDataWorkerTest.kt
+++ b/app/src/test/java/com/andryoga/safebox/worker/RestoreDataWorkerTest.kt
@@ -201,7 +201,8 @@ class RestoreDataWorkerTest {
         val result = worker.doWork()
 
         assertThat(result).isEqualTo(Result.failure())
-        assertThat(analyticsHelper.hasLogged(AnalyticsKey.RESTORE_DATA_FAILURE)).isTrue()
+        assertThat(analyticsHelper.hasLogged(AnalyticsKey.RESTORE_DATA_WRONG_PASSWORD)).isTrue()
+        assertThat(analyticsHelper.hasLogged(AnalyticsKey.RESTORE_DATA_FAILURE)).isFalse()
     }
 
     @Test


### PR DESCRIPTION
### **User description**
## Description

## Impacted Issue number
Closes #216

## Type of change
Enhancement


___

### **PR Type**
Enhancement


___

### **Description**
- Allow creating backups with any custom password without master password validation

- Classify restore errors into incorrect password, corrupt file, and unknown failures

- Update UI to show specific error messages for corrupt backup files

- Add analytics tracking for backup initiation and restore errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  User["User"] -- "Enters Password" --> VM["NewBackupOrRestoreVM"]
  VM -- "Enqueues Work" --> Worker["RestoreDataWorker / BackupDataWorker"]
  Worker -- "Outputs RestoreFailureReason" --> VM
  VM -- "Updates WorkflowState" --> UI["NewBackupOrRestoreScreen"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>BackupAndRestoreScreenTest.kt</strong><dd><code>Add UI test for corrupt backup file state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-fecb02a74197147bc41467a32d1aad74869c97a771654b585cdc4580deb471a4">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NewBackupOrRestoreVMTest.kt</strong><dd><code>Update VM tests for unconstrained backup passwords and restore </code><br><code>failures</code></dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-f140743b89d952330ed9d23bdc77dd4780b27acb719efdd53f2bd26fca8aa38c">+64/-43</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RestoreFailureReasonTest.kt</strong><dd><code>Add unit tests for RestoreFailureReason serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-02464c8050e51ad8eebf1fadb00cc2785c60f94d929c6ee1cf803226cdd6efb2">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BackupDataWorkerTest.kt</strong><dd><code>Verify backup success analytics logging in worker tests</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-94753ebf07b73c57c817996c5607f4eebe120912739c72c6cb051890baf93857">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RestoreDataWorkerTest.kt</strong><dd><code>Update restore worker unit tests for typed failure outputs</code></dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-000ea958813a913fbf2f6174fa74e76eb982a1264f56935907ea434461f47b66">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>AnalyticsKey.kt</strong><dd><code>Add BACKUP_STARTED analytics key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-a4c29c553d808db78494df5e61b9fd26b967cf57850bf2ec4eb86241f7a4b0c3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NewBackupOrRestoreScreen.kt</strong><dd><code>Handle corrupt file state in restore dialog UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-03f32673abbb7cf7f445d91dda5186be55a14fb53c2820586b8130ea34e071fd">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NewBackupOrRestoreVM.kt</strong><dd><code>Remove master password check for backups and parse restore failure </code><br><code>reasons</code></dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-0b0aab8dc757b6a243491988a3921dcfc0c906af49695d91930d1e67d621063f">+38/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RestoreFailureReason.kt</strong><dd><code>Define enum and WorkData converters for restore failure causes</code></dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-4bba827bad87fb624442258abca024d2f3de938d8201056c32028dc55cecf6c6">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ScreenState.kt</strong><dd><code>Add CORRUPT_FILE state to WorkflowState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-0700b49e88a9edabfb5b8833ad8843fcdd8b25bafc71a7cc9a6ab43efe4b260d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BackupDataWorker.kt</strong><dd><code>Log analytics event on successful backup completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-694fe345a452ebccc47f9298e13747babb4e45bb60ce81c431c719b8dcbaf702">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RestoreDataWorker.kt</strong><dd><code>Pass granular restore failure reasons via output WorkData</code></dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-108c9982ead4f632b29a639567c8a25447bcb37a955be0edf7ff3269637babfc">+30/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>strings.xml</strong><dd><code>Update backup prompt texts and add corrupt restore message</code></dd></td>
  <td><a href="https://github.com/Ni3verma/Safe-Box/pull/222/files#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restore failures now distinguish incorrect passwords, corrupt files, and other errors.
  * Added a clear corrupt-backup message with an “OK” dismissal option.
  * Backup and restore activity now records more detailed progress and completion events.

* **Improvements**
  * Updated backup instructions, password guidance, progress text, and completion messaging.
  * Backup confirmation now proceeds without pre-validating the password.

* **Tests**
  * Added coverage for corrupt-file restore messaging, failure states, analytics, and backup success scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->